### PR TITLE
Wrong URL about base64 encoded data

### DIFF
--- a/View.php
+++ b/View.php
@@ -153,6 +153,8 @@ class View extends \yii\web\View
                         $path = dirname($file);
                         $result = [];
                         foreach ($m[0] as $k => $v) {
+                            if ( 0 === strpos( $m[1][$k], 'data:' ) )
+                                continue;
                             $url = str_replace(['\'', '"'], '', $m[1][$k]);
                             if (preg_match('#^(' . implode('|', $this->schemas) . ')#is', $url)) {
                                 $result[$m[1][$k]] = '\'' . $url . '\'';


### PR DESCRIPTION
Do not prepend assets path to base64 encoded data in css image url.

e.g
When using Yii-Debug, some image url using base64 encoded data will always be prepended assets path too, please ignore them.
refer to css: [@vendor/yiisoft/yii2-debug/assets/toolbar.css](https://github.com/yiisoft/yii2-debug/blob/master/assets/toolbar.css), line 15 and line 173

HTML 404 error

```
https://www.example.com/assets/1b70d06/data:image/svg+xml;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAoCAYAAAA/tpB3AAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB94BBQwuINct3v0AAAAjSURBVAjXY3j79u1/JgYGBgYkgpGRkYEYMSpKUGLK+/fvGQAaDAb6F86IsAAAAABJRU5ErkJggg==
```
