### PR TITLE
Handle asset versioning

### DIFF
--- a/View.php
+++ b/View.php
@@ -176,6 +176,7 @@ class View extends \yii\web\View
             $css = '';
 
             foreach ($files as $file => $html) {
+                $file = (strpos($file, "?")) ? strstr($file, "?", true) : $file;
                 $file = str_replace(\Yii::getAlias($this->web_path), '', $file);
 
                 $content = file_get_contents(\Yii::getAlias($this->base_path) . $file);
@@ -284,6 +285,7 @@ class View extends \yii\web\View
         if (!file_exists($resultFile)) {
             $js = '';
             foreach ($files as $file => $html) {
+                $file = (strpos($file, "?")) ? strstr($file, "?", true) : $file;
                 $file = $this->getAbsoluteFilePath($file);
                 $js .= file_get_contents($file) . ';' . PHP_EOL;
             }

--- a/View.php
+++ b/View.php
@@ -176,7 +176,7 @@ class View extends \yii\web\View
             $css = '';
 
             foreach ($files as $file => $html) {
-                $file = (strpos($file, "?")) ? strstr($file, "?", true) : $file;
+                $file = (strpos($file, "?")) ? parse_url($file, PHP_URL_PATH) : $file;
                 $file = str_replace(\Yii::getAlias($this->web_path), '', $file);
 
                 $content = file_get_contents(\Yii::getAlias($this->base_path) . $file);
@@ -285,7 +285,7 @@ class View extends \yii\web\View
         if (!file_exists($resultFile)) {
             $js = '';
             foreach ($files as $file => $html) {
-                $file = (strpos($file, "?")) ? strstr($file, "?", true) : $file;
+                $file = (strpos($file, "?")) ? parse_url($file, PHP_URL_PATH) : $file;
                 $file = $this->getAbsoluteFilePath($file);
                 $js .= file_get_contents($file) . ';' . PHP_EOL;
             }

--- a/tests/unit/view/ViewTest.php
+++ b/tests/unit/view/ViewTest.php
@@ -33,6 +33,7 @@ class ViewTest extends minify\tests\unit\TestCase
         $this->getView()->endPage(false);
 
         $files = FileHelper::findFiles($this->getView()->minify_path);
+
         $this->assertEquals(2, count($files));
 
         foreach ($files as $file) {
@@ -50,6 +51,51 @@ class ViewTest extends minify\tests\unit\TestCase
         ob_start();
         echo '<html>This is test page</html>';
         $this->getView()->endPage(false);
+    }
+
+    public function testMainWithVersion()
+    {
+        $view = $this->getView();
+        $view->assetManager->appendTimestamp = true;
+
+        $this->assertInstanceOf('rmrevin\yii\minify\View', $view);
+
+        $this->assertEquals('CP1251', $view->force_charset);
+    }
+
+    public function testEndPageWithVersion()
+    {
+        $view = $this->getView();
+        $view->assetManager->appendTimestamp = true;
+
+        minify\tests\unit\data\TestAssetBundle::register($view);
+
+        ob_start();
+        echo '<html>This is test page with versioning</html>';
+        $view->endPage(false);
+
+        $files = FileHelper::findFiles($view->minify_path);
+
+        $this->assertEquals(2, count($files));
+
+        foreach ($files as $file) {
+            $this->assertNotEmpty(file_get_contents($file));
+        }
+    }
+
+    public function testAlternativeEndPageWithVersion()
+    {
+        $view = $this->getView();
+        $view->assetManager->appendTimestamp = true;
+
+        $view->expand_imports = false;
+        $view->force_charset = false;
+
+        minify\tests\unit\data\TestAssetBundle::register($view);
+
+        ob_start();
+        echo '<html>This is test page versioning</html>';
+        $view->endPage(false);
     }
 
     /**


### PR DESCRIPTION
Fixed up an error where it was trying to open file names with the version string added (?=<version>) if appendTimestamp was set to true for the assetManager. Added relevent test cases