### PR TITLE
Fix issue with initScriptFilter()

### DIFF
--- a/View.php
+++ b/View.php
@@ -114,7 +114,7 @@ class View extends \yii\web\View
             $this->registerAssetFiles($bundle);
         }
 
-        if (true === $this->enableMinify) {
+        if (true === $this->enableMinify && !$ajaxMode) {
             if (true === $this->minifyCss) {
                 $this->minifyCSS();
             }


### PR DESCRIPTION
Function initScriptFilter()  (vendor\yiisoft\yii2\assets\yii.js:370) now can filter scripts correctly with ajax requests