### PR TITLE
Copy CSS print query from link to minified CSS

### DIFF
--- a/components/CSS.php
+++ b/components/CSS.php
@@ -97,6 +97,10 @@ class CSS extends MinifyComponent
                     $content = strtr($content, $result);
                 }
 
+                if (preg_match('/\bmedia="print"/', $html, $m)) {
+                    $content = '@media print {' . $content . '}';
+                }
+                
                 $css .= $content;
             }
 

--- a/components/CSS.php
+++ b/components/CSS.php
@@ -97,7 +97,7 @@ class CSS extends MinifyComponent
                     $content = strtr($content, $result);
                 }
                 
-                self::convertMediaTypeAttributeToMediaQuery($html, $content);
+                $content = self::convertMediaTypeAttributeToMediaQuery($html, $content);
 
                 $css .= $content;
             }

--- a/components/CSS.php
+++ b/components/CSS.php
@@ -96,11 +96,9 @@ class CSS extends MinifyComponent
 
                     $content = strtr($content, $result);
                 }
-
-                if (preg_match('/\bmedia="print"/', $html, $m)) {
-                    $content = '@media print {' . $content . '}';
-                }
                 
+                self::convertMediaTypeAttributeToMediaQuery($html, $content);
+
                 $css .= $content;
             }
 
@@ -253,5 +251,21 @@ class CSS extends MinifyComponent
         }
 
         return $result;
+    }
+    
+    /**
+     * If the <link> tag has a media="type" attribute, wrap the content in an equivalent media query
+     * @param string $tag_html HTML of the link tag
+     * @param string $content CSS content
+     * @return string $content CSS content wrapped with media query, if applicable
+     */
+    public static function convertMediaTypeAttributeToMediaQuery($html, $content)
+    {
+        if (preg_match('/\bmedia=(["\'])([^"\']+)\1/i', $html, $m)) {
+            if ($m[2] !== 'all') {
+                $content = '@media '.$m[2].'{' . $content . '}';
+            }
+        }        
+        return $content;
     }
 }

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -15,7 +15,7 @@ use yii\helpers\FileHelper;
  * @package rmrevin\yii\fontawesome\tests\unit
  * This is the base class for all yii framework unit tests.
  */
-abstract class TestCase extends \PHPUnit\Framework\TestCase
+abstract class TestCase extends \PHPUnit_Framework_TestCase
 {
 
     public static $params;

--- a/tests/unit/view/CSSTest.php
+++ b/tests/unit/view/CSSTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * JsMinifyTest.php
+ * @author Dylan Ferris
+ * @link https://github.com/acerix
+ */
+
+namespace rmrevin\yii\minify\tests\unit\view;
+
+use rmrevin\yii\minify\components\CSS;
+use rmrevin\yii\minify\tests\unit\TestCase;
+
+/**
+ * Class CSSTest
+ * @package rmrevin\yii\minify\tests\unit\view
+ */
+class CSSTest extends TestCase
+{
+
+    public function testConvertMediaTypeAttributeToMediaQuery()
+    {
+
+        $tests = [
+            [
+                'html' => '<link href="test.css" media="all" rel="stylesheet">',
+                'content' => '.always{}',
+                'result' => '.always{}'
+            ],
+            [
+                'html' => '<link href="test.css" rel="stylesheet" media="print">',
+                'content' => '.only_print{}',
+                'result' => '@media print{.only_print{}}'
+            ],
+            [
+                'html' => "<link media='screen' rel='stylesheet' href='test.css'>",
+                'content' => '.only_screen{}',
+                'result' => '@media screen{.only_screen{}}'
+            ]
+        ];
+        
+        foreach ($tests as $css_file) {
+            $this->assertEquals(
+                $css_file['result'],
+                CSS::convertMediaTypeAttributeToMediaQuery($css_file['html'], $css_file['content'])
+            );
+        }
+        
+
+    }
+}

--- a/tests/unit/view/CSSTest.php
+++ b/tests/unit/view/CSSTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * JsMinifyTest.php
+ * CSSTest.php
  * @author Dylan Ferris
  * @link https://github.com/acerix
  */


### PR DESCRIPTION
For example, fullcalendar includes a separate CSS file for printers like this:
```html
<link href="fullcalendar.print.css" rel="stylesheet" media="print">
```
The media="print" part currently gets lost, so CSS which is intended for printers only is applied on screen view.

The patch puts wraps such CSS with `@media print {}` so it only applies on printers.