### PR TITLE
Update to PHPUnit 6 namespace

### DIFF
--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -15,7 +15,7 @@ use yii\helpers\FileHelper;
  * @package rmrevin\yii\fontawesome\tests\unit
  * This is the base class for all yii framework unit tests.
  */
-abstract class TestCase extends \PHPUnit_Framework_TestCase
+abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
 
     public static $params;


### PR DESCRIPTION
This is to fix the error running tests with PHPUnit 6:

`PHP Fatal error:  Class 'PHPUnit_Framework_TestCase' not found in yii2-minify-view/tests/unit/TestCase.php on line 18`

Starting with version 6, \PHPUnit_Framework_TestCase was renamed to \PHPUnit\Framework\TestCase.

https://stackoverflow.com/a/42561590
